### PR TITLE
Fix subscribe

### DIFF
--- a/GreeMQTT/device.py
+++ b/GreeMQTT/device.py
@@ -22,7 +22,7 @@ class Device:
         is_GCM: bool = False,
         key: Optional[str] = None,
     ):
-        self.ip = device_ip
+        self.device_ip = device_ip
         self.device_id = device_id
         self.name = name
         self.is_GCM = is_GCM
@@ -32,8 +32,12 @@ class Device:
     def topic(self) -> str:
         return f"{MQTT_TOPIC}/{self.device_id}"
 
+    @property
+    def set_topic(self) -> str:
+        return f"{self.topic}/set"
+
     def __str__(self):
-        return f"Device(ip={self.ip}, device_id={self.device_id}, GCM={self.is_GCM})"
+        return f"Device(ip={self.device_ip}, device_id={self.device_id}, GCM={self.is_GCM})"
 
     def encrypt_request(self, pack: str) -> str:
         request = {"cid": "app", "i": 0, "t": "pack", "uid": 0, "tcid": self.device_id}
@@ -71,8 +75,8 @@ class Device:
                 self.transport.close()
 
         transport, protocol = await loop.create_datagram_endpoint(
-            lambda: UDPClientProtocol(self.ip),
-            remote_addr=(self.ip, UDP_PORT),
+            lambda: UDPClientProtocol(self.device_ip),
+            remote_addr=(self.device_ip, UDP_PORT),
         )
         try:
             await asyncio.wait_for(on_con_lost, timeout=SOCKET_TIMEOUT)

--- a/GreeMQTT/device_db.py
+++ b/GreeMQTT/device_db.py
@@ -1,6 +1,8 @@
 import sqlite3
-from typing import Optional, Tuple, List
 import os
+from typing import Optional, List
+
+from GreeMQTT.device import Device
 
 DB_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "devices.db")
 
@@ -15,8 +17,8 @@ class DeviceDB:
         c = conn.cursor()
         c.execute("""
             CREATE TABLE IF NOT EXISTS devices (
-                mac TEXT PRIMARY KEY,
-                ip TEXT NOT NULL,
+                device_id TEXT PRIMARY KEY,
+                device_ip TEXT NOT NULL,
                 is_gcm INTEGER NOT NULL,
                 `key` TEXT NOT NULL
             )
@@ -24,27 +26,48 @@ class DeviceDB:
         conn.commit()
         conn.close()
 
-    def get_device(self, mac: str) -> Optional[Tuple[str, str, str, int]]:
+    def get_device(self, mac: str) -> Optional[Device]:
         conn = sqlite3.connect(self.db_path)
         c = conn.cursor()
-        c.execute("SELECT mac, ip, `key`, is_gcm FROM devices WHERE mac = ?", (mac,))
+        c.execute(
+            "SELECT mac, device_ip, `key`, is_gcm FROM devices WHERE mac = ?", (mac,)
+        )
         row = c.fetchone()
         conn.close()
-        return row
+        return (
+            Device(
+                device_id=row[0],
+                device_ip=row[1],
+                key=row[2],
+                is_GCM=bool(row[3]),
+                name="Load from DB",
+            )
+            if row
+            else None
+        )
 
-    def get_all_devices(self) -> List[Tuple[str, str, str, int]]:
+    def get_all_devices(self) -> List[Device]:
         conn = sqlite3.connect(self.db_path)
         c = conn.cursor()
-        c.execute("SELECT mac, ip, `key`, is_gcm FROM devices")
+        c.execute("SELECT device_id, device_ip, `key`, is_gcm FROM devices")
         rows = c.fetchall()
         conn.close()
-        return rows
+        return [
+            Device(
+                device_id=row[0],
+                device_ip=row[1],
+                key=row[2],
+                is_GCM=bool(row[3]),
+                name="Load from DB",
+            )
+            for row in rows
+        ]
 
     def save_device(self, mac: str, ip: str, key: str, is_gcm: bool = False):
         conn = sqlite3.connect(self.db_path)
         c = conn.cursor()
         c.execute(
-            "REPLACE INTO devices (mac, ip, `key`, is_gcm) VALUES (?, ?, ?, ?)",
+            "REPLACE INTO devices (device_id, device_ip, `key`, is_gcm) VALUES (?, ?, ?, ?)",
             (mac, ip, key, int(is_gcm)),
         )
         conn.commit()

--- a/GreeMQTT/main.py
+++ b/GreeMQTT/main.py
@@ -1,66 +1,52 @@
 import asyncio
 
+from typing import List
+
 from GreeMQTT import logger
 from GreeMQTT.config import NETWORK
 from GreeMQTT.mqtt_client import create_mqtt_client
 from GreeMQTT.device import Device
 from GreeMQTT.device_db import device_db
 from GreeMQTT.managers import DeviceRetryManager, start_device_tasks
+from GreeMQTT.mqtt_handler import handle_set_params
 
 
 async def main():
-    tasks = []
     stop_event = asyncio.Event()
 
     # Load known devices from DB
-    known_devices = {
-        mac: (ip, key, is_gcm) for mac, ip, key, is_gcm in device_db.get_all_devices()
-    }
-    missing_devices = []
+    known_devices: List[Device] = device_db.get_all_devices()
+    known_ips = [device.device_ip for device in known_devices]
+    missing_devices = [ip for ip in NETWORK if ip not in known_ips]
 
     async with await create_mqtt_client() as mqtt_client:
-        for device_ip in NETWORK:
-            device = None
-            # Try to use known device from DB
-            for mac, (ip, key, is_gcm) in known_devices.items():
-                if ip == device_ip:
-                    device = Device(
-                        device_ip=ip,
-                        device_id=mac,
-                        name="Load from DB",
-                        is_GCM=is_gcm == 1,
-                        key=key,
-                    )
-                    logger.info(f"Loaded device from DB: {device}")
-                    break
-            # If not found in DB, search for the device
-            if not device:
-                device = await Device.search_devices(device_ip)
-                if device and device.key:
-                    logger.info(f"Device found: {device}")
-                    device_db.save_device(
-                        device.device_id, device.ip, device.key, device.is_GCM
-                    )
-                else:
-                    logger.warning(f"Device not found: {device_ip}")
-                    missing_devices.append(device_ip)
-            if device:
-                # Start async tasks for periodic updates
-                tasks.extend(await start_device_tasks(device, mqtt_client, stop_event))
+        # Start tasks for known devices
+        for device in known_devices:
+            await start_device_tasks(device, mqtt_client, stop_event)
 
+        # If not found in DB, search for the device
+        for device_ip in missing_devices:
+            device = await Device.search_devices(device_ip)
+            if device and device.key:
+                logger.info(f"Device found: {device}")
+                device_db.save_device(
+                    device.device_id, device.device_ip, device.key, device.is_GCM
+                )
+                missing_devices.remove(device_ip)
+                await start_device_tasks(device, mqtt_client, stop_event)
         # Start retry task
         if missing_devices:
             retry_manager = DeviceRetryManager(missing_devices, mqtt_client, stop_event)
-            retry_task = asyncio.create_task(retry_manager.run())
-            await retry_task
+            asyncio.create_task(retry_manager.run())
         else:
             logger.info("All devices found.")
+
+        await asyncio.create_task(handle_set_params(mqtt_client, stop_event))
 
         # Keep the main task alive
         try:
             while True:
-                await asyncio.sleep(1)
+                await asyncio.sleep(0.1)
         except KeyboardInterrupt:
             logger.info("Exiting...")
             stop_event.set()
-            await asyncio.gather(*tasks, return_exceptions=True)

--- a/GreeMQTT/mqtt_client.py
+++ b/GreeMQTT/mqtt_client.py
@@ -1,6 +1,5 @@
 import aiomqtt
 from aiomqtt import Will
-
 from GreeMQTT.config import (
     MQTT_BROKER,
     MQTT_TOPIC,

--- a/GreeMQTT/mqtt_handler.py
+++ b/GreeMQTT/mqtt_handler.py
@@ -1,6 +1,9 @@
 import asyncio
 from functools import wraps
 import json
+import traceback
+
+from aiomqtt import Client
 
 from GreeMQTT import logger
 from GreeMQTT.config import UPDATE_INTERVAL
@@ -8,8 +11,12 @@ from GreeMQTT.device import Device
 
 from typing import Callable
 
+DEVICES = {}
+
 
 def async_safe_handle(func: Callable) -> Callable:
+    """Decorator to safely handle async functions with stop_event and log errors with traceback."""
+
     @wraps(func)
     async def wrapper(*args, **kwargs):
         stop_event = args[2] if len(args) > 2 else kwargs.get("stop_event")
@@ -17,7 +24,7 @@ def async_safe_handle(func: Callable) -> Callable:
             try:
                 return await func(*args, **kwargs)
             except Exception as e:
-                logger.error(f"Error in {func.__name__}: {e}")
+                logger.error(f"Error in {func.__name__}: {e}\n{traceback.format_exc()}")
                 await asyncio.sleep(1)
         logger.info(f"{func.__name__} stopped due to stop_event.")
         return None
@@ -26,38 +33,39 @@ def async_safe_handle(func: Callable) -> Callable:
 
 
 @async_safe_handle
-async def handle_set_params(
-    device: Device,
-    mqtt_client,
-    stop_event: asyncio.Event,
-    qos: int,
-):
-    set_topic = f"{device.topic}/set"
-    messages = mqtt_client.messages
+async def handle_set_subscribe(device: Device, mqtt_client: Client, qos: int):
+    set_topic = device.set_topic
     await mqtt_client.subscribe(set_topic, qos=qos)
     logger.info(f"Subscribed to topic {set_topic} with QoS {qos}")
+    DEVICES[set_topic] = device
+
+
+@async_safe_handle
+async def handle_set_params(mqtt_client: Client, stop_event: asyncio.Event):
+    messages = mqtt_client.messages
     async for message in messages:
         if stop_event.is_set():
             break
-        if message.topic == set_topic:
-            logger.info(f"Received message on topic {message.topic}: {message.payload}")
-            try:
-                params = json.loads(message.payload.decode("utf-8"))
-                await device.set_params(params)
-            except json.JSONDecodeError:
-                logger.error(
-                    f"Invalid JSON received on topic {message.topic}: {message.payload}"
-                )
+        device = DEVICES.get(str(message.topic))
+        logger.info(f"Received message on topic {message.topic}: {message.payload}")
+        try:
+            params = json.loads(message.payload.decode("utf-8"))
+            await device.set_params(params)
+        except json.JSONDecodeError:
+            logger.error(
+                f"Invalid JSON received on topic {message.topic}: {message.payload}"
+            )
 
 
 @async_safe_handle
 async def handle_get_params(
     device: Device,
-    mqtt_client,
+    mqtt_client: Client,
     stop_event: asyncio.Event,
     qos: int,
     retain: bool,
 ):
+    """Periodically publishes device parameters to the MQTT topic."""
     params_topic = device.topic
     logger.info(f"Publishing device parameters to topic {params_topic}.")
     while not stop_event.is_set():

--- a/GreeMQTT/mqtt_handler.py
+++ b/GreeMQTT/mqtt_handler.py
@@ -47,6 +47,9 @@ async def handle_set_params(mqtt_client: Client, stop_event: asyncio.Event):
         if stop_event.is_set():
             break
         device = DEVICES.get(str(message.topic))
+        if device is None:
+            logger.warning(f"No device found for topic {message.topic}. Skipping message.")
+            continue
         logger.info(f"Received message on topic {message.topic}: {message.payload}")
         try:
             params = json.loads(message.payload.decode("utf-8"))


### PR DESCRIPTION
This pull request refactors the handling of devices in the `GreeMQTT` project to improve code clarity, consistency, and functionality. Key changes include renaming variables for better readability, refactoring database interactions to return `Device` objects instead of raw tuples, and enhancing MQTT message handling by introducing a centralized device registry. The changes also simplify the task management logic for device operations.

### Device Handling and Refactoring:
* Renamed `ip` to `device_ip` across the codebase for consistency and clarity in `GreeMQTT/device.py` and related files. (`[[1]](diffhunk://#diff-a298193485407da746b69d2266e650260749e6819ede0984f6868aad2e7b1df7L25-R25)`, `[[2]](diffhunk://#diff-a298193485407da746b69d2266e650260749e6819ede0984f6868aad2e7b1df7L74-R79)`)
* Added a `set_topic` property to the `Device` class for generating MQTT set topics dynamically. (`[GreeMQTT/device.pyR35-R40](diffhunk://#diff-a298193485407da746b69d2266e650260749e6819ede0984f6868aad2e7b1df7R35-R40)`)

### Database Interaction Improvements:
* Updated `GreeMQTT/device_db.py` to return `Device` objects instead of raw tuples when retrieving devices from the database. This ensures a more object-oriented approach. (`[GreeMQTT/device_db.pyL18-R70](diffhunk://#diff-eac5e572bba4a4ab1fd19eb042a823ef723483f111558f59ff584e6fbee490c2L18-R70)`)
* Renamed database columns from `mac` and `ip` to `device_id` and `device_ip` for consistency with the `Device` class. (`[GreeMQTT/device_db.pyL18-R70](diffhunk://#diff-eac5e572bba4a4ab1fd19eb042a823ef723483f111558f59ff584e6fbee490c2L18-R70)`)

### MQTT Message Handling Enhancements:
* Introduced a centralized `DEVICES` registry in `GreeMQTT/mqtt_handler.py` to map MQTT topics to their corresponding `Device` objects. This simplifies message processing. (`[[1]](diffhunk://#diff-74d4e39cdd4da5915a96d837f18f0d1c5dbb2078f07e4703356df119cd5a8ae2R4-R27)`, `[[2]](diffhunk://#diff-74d4e39cdd4da5915a96d837f18f0d1c5dbb2078f07e4703356df119cd5a8ae2L29-R49)`)
* Refactored `handle_set_params` to separate subscription logic (`handle_set_subscribe`) and centralized message handling for `set` topics. (`[[1]](diffhunk://#diff-74d4e39cdd4da5915a96d837f18f0d1c5dbb2078f07e4703356df119cd5a8ae2L29-R49)`, `[[2]](diffhunk://#diff-74d4e39cdd4da5915a96d837f18f0d1c5dbb2078f07e4703356df119cd5a8ae2L56-R68)`)

### Task Management Simplification:
* Removed the `tasks` list in `start_device_tasks` and `DeviceRetryManager`, directly creating and managing tasks without returning them. (`[[1]](diffhunk://#diff-4dfe7607f0dc05f43baf829056c04f1e9c73b8ca99b8d5c061d631dc6d5f8368L22-L36)`, `[[2]](diffhunk://#diff-4dfe7607f0dc05f43baf829056c04f1e9c73b8ca99b8d5c061d631dc6d5f8368L45-R48)`)
* Simplified the retry logic in `DeviceRetryManager` by breaking out of the loop once all missing devices are found. (`[GreeMQTT/managers.pyL45-R48](diffhunk://#diff-4dfe7607f0dc05f43baf829056c04f1e9c73b8ca99b8d5c061d631dc6d5f8368L45-R48)`)

### Miscellaneous:
* Added traceback logging for better error diagnostics in asynchronous functions. (`[GreeMQTT/mqtt_handler.pyR4-R27](diffhunk://#diff-74d4e39cdd4da5915a96d837f18f0d1c5dbb2078f07e4703356df119cd5a8ae2R4-R27)`)