### PR TITLE
Auto discovery

### DIFF
--- a/GreeMQTT/config.py
+++ b/GreeMQTT/config.py
@@ -10,6 +10,16 @@ load_dotenv()
 
 
 def get_env_list(var_name: str, default: str = None) -> List[str]:
+    """
+    Retrieves a list of values from an environment variable.
+
+    Args:
+        var_name (str): The name of the environment variable.
+        default (str, optional): A default comma-separated string to use if the environment variable is not set. Defaults to None.
+
+    Returns:
+        List[str]: A list of non-empty, stripped values. Returns an empty list if the environment variable is unset or empty.
+    """
     value = os.getenv(var_name, default)
     if value is None or value.strip() == "":
         return []

--- a/GreeMQTT/config.py
+++ b/GreeMQTT/config.py
@@ -1,6 +1,8 @@
 import os
 from typing import List
+
 from dotenv import load_dotenv
+
 from GreeMQTT.logger import log
 
 # Load environment variables from .env file
@@ -9,8 +11,8 @@ load_dotenv()
 
 def get_env_list(var_name: str, default: str = None) -> List[str]:
     value = os.getenv(var_name, default)
-    if value is None:
-        raise ValueError(f"{var_name} environment variable is not set.")
+    if value is None or value.strip() == "":
+        return []
     return [item.strip() for item in value.split(",") if item.strip()]
 
 

--- a/GreeMQTT/device/device.py
+++ b/GreeMQTT/device/device.py
@@ -1,13 +1,13 @@
 import datetime
 import json
-from typing import Optional, Dict, Self
+from typing import Dict, Optional, Self
 
-from GreeMQTT.logger import log
 from GreeMQTT.config import MQTT_TOPIC
+from GreeMQTT.device.device_command_builder import DeviceCommandBuilder
+from GreeMQTT.device.device_communication import DeviceCommunicator
 from GreeMQTT.device.device_encryption import DeviceEncryptor
 from GreeMQTT.device.device_param_converter import DeviceParamConverter
-from GreeMQTT.device.device_communication import DeviceCommunicator
-from GreeMQTT.device.device_command_builder import DeviceCommandBuilder
+from GreeMQTT.logger import log
 
 
 class Device:

--- a/GreeMQTT/device/device_command_builder.py
+++ b/GreeMQTT/device/device_command_builder.py
@@ -1,4 +1,5 @@
 import json
+
 from GreeMQTT.config import TRACKING_PARAMS
 
 

--- a/GreeMQTT/device/device_db.py
+++ b/GreeMQTT/device/device_db.py
@@ -1,6 +1,6 @@
-import sqlite3
 import os
-from typing import Optional, List
+import sqlite3
+from typing import List, Optional
 
 from GreeMQTT.device.device import Device
 

--- a/GreeMQTT/device/device_encryption.py
+++ b/GreeMQTT/device/device_encryption.py
@@ -1,5 +1,6 @@
-from typing import Optional, Dict
-from GreeMQTT.encryptor import encrypt, decrypt
+from typing import Dict, Optional
+
+from GreeMQTT.encryptor import decrypt, encrypt
 
 
 class DeviceEncryptor:

--- a/GreeMQTT/device/device_param_converter.py
+++ b/GreeMQTT/device/device_param_converter.py
@@ -1,6 +1,5 @@
-from datetime import datetime, UTC
-from typing import Dict, Any
-
+from datetime import UTC, datetime
+from typing import Any, Dict
 
 CONVERT_PARAMS: Dict[str, Dict[int, str]] = {
     "Mod": {

--- a/GreeMQTT/device/device_retry_manager.py
+++ b/GreeMQTT/device/device_retry_manager.py
@@ -2,9 +2,9 @@ import asyncio
 
 from aiomqtt import Client
 
-from GreeMQTT.logger import log
-from GreeMQTT.device.device import Device
 from GreeMQTT import device_db
+from GreeMQTT.device.device import Device
+from GreeMQTT.logger import log
 from GreeMQTT.mqtt_handler import start_device_tasks
 
 

--- a/GreeMQTT/encryptor.py
+++ b/GreeMQTT/encryptor.py
@@ -1,10 +1,10 @@
 import base64
 import json
-from typing import Optional, Any, Dict
+from typing import Any, Dict, Optional
 
 from Crypto.Cipher import AES
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 GENERIC_KEY = "a3K8Bx%2r8Y7#xDh"
 GENERIC_GCM_KEY = "{yxAHAY_Lm6pbC/<"

--- a/GreeMQTT/logger.py
+++ b/GreeMQTT/logger.py
@@ -1,4 +1,5 @@
 import logging
+
 import structlog
 
 structlog.configure(

--- a/GreeMQTT/mqtt_client.py
+++ b/GreeMQTT/mqtt_client.py
@@ -1,14 +1,8 @@
 import aiomqtt
 from aiomqtt import Will
-from GreeMQTT.config import (
-    MQTT_BROKER,
-    MQTT_TOPIC,
-    MQTT_PASSWORD,
-    MQTT_PORT,
-    MQTT_USER,
-    MQTT_QOS,
-    MQTT_KEEP_ALIVE,
-)
+
+from GreeMQTT.config import (MQTT_BROKER, MQTT_KEEP_ALIVE, MQTT_PASSWORD,
+                             MQTT_PORT, MQTT_QOS, MQTT_TOPIC, MQTT_USER)
 
 
 async def create_mqtt_client() -> aiomqtt.Client:

--- a/GreeMQTT/mqtt_handler.py
+++ b/GreeMQTT/mqtt_handler.py
@@ -1,17 +1,15 @@
 import asyncio
-from functools import wraps
 import json
 import traceback
+from functools import wraps
+from typing import Callable
 
 from aiomqtt import Client
 
+from GreeMQTT.config import MQTT_QOS, MQTT_RETAIN, UPDATE_INTERVAL
+from GreeMQTT.device.device import Device
 from GreeMQTT.device.device_registry import DeviceRegistry
 from GreeMQTT.logger import log
-from GreeMQTT.config import UPDATE_INTERVAL, MQTT_QOS, MQTT_RETAIN
-from GreeMQTT.device.device import Device
-
-from typing import Callable
-
 
 device_registry = DeviceRegistry()
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ The application periodically retrieves and publishes device parameters to the sp
 MQTT_TOPIC/deviceId/set {"Pow":1,"SetTem":24}
 ```
 
+## Automatic Device Discovery
+If the `NETWORK` environment variable is not set, GreeMQTT will automatically scan your local network for compatible Gree devices on port 7000. This makes setup easier, as you do not need to manually specify device IP addresses. The discovered devices will be added to the internal database and managed automatically.
+
 ### Home Assistant Integration
 Add the following to your Home Assistant `configuration.yaml` to subscribe to GreeMQTT topics:
 ```yaml


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the `GreeMQTT` project, focusing on adding automatic network scanning for device discovery, improving code readability, and restructuring imports. The key changes include implementing subnet scanning for device discovery, refactoring device management logic, and cleaning up imports across multiple files.

### New Features:
* **Automatic Network Scanning**: Added a new `scan_port_7000_on_subnet` function and integrated it into the `GreeMQTTApp` class to automatically discover devices on the local network if the `NETWORK` environment variable is not set. This simplifies setup by eliminating the need for manual IP configuration. [[1]](diffhunk://#diff-75b6dbf7c0afe13c206a3f701a82be72dc895e29fe420731896297d08eacde9fR2-R82) [[2]](diffhunk://#diff-75b6dbf7c0afe13c206a3f701a82be72dc895e29fe420731896297d08eacde9fL59-R103)
* **README Update**: Documented the new automatic device discovery feature in the README, explaining how it works and its benefits.

### Code Refactoring:
* **Device Management Logic**: Refactored methods in the `GreeMQTTApp` class (`load_devices`, `start_devices`, and `add_missing_devices`) to streamline device handling and align with the new network scanning feature. [[1]](diffhunk://#diff-75b6dbf7c0afe13c206a3f701a82be72dc895e29fe420731896297d08eacde9fR2-R82) [[2]](diffhunk://#diff-75b6dbf7c0afe13c206a3f701a82be72dc895e29fe420731896297d08eacde9fL59-R103)
* **Improved Environment Variable Handling**: Updated the `get_env_list` function in `GreeMQTT/config.py` to return an empty list instead of raising an error when an environment variable is not set or is empty.

### Import Cleanup:
* **Consistent Import Formatting**: Reorganized and optimized imports across multiple files for better readability and adherence to PEP 8 standards. Examples include `GreeMQTT/device/device.py`, `GreeMQTT/device/device_db.py`, and `GreeMQTT/mqtt_client.py`. [[1]](diffhunk://#diff-8e01eedb7d99e1664da8f09f5010ba8f2b1a97a64ab281b338cf72d2f98c8e53L3-R10) [[2]](diffhunk://#diff-53894f48530fd501ab8048e938950322ef1f9ce93aa0ccfaa5d8e3cbcc10fa30L1-R3) [[3]](diffhunk://#diff-81dbaccedc26ea0dfb6fe822bff70a26616820a2f255758e095aa1c3b3282358L3-R5)